### PR TITLE
Query via "VPN lookalike" tunnel

### DIFF
--- a/bin/submit_to_cluster
+++ b/bin/submit_to_cluster
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+"""
+"""
+from stormdb.process import submit_to_cluster
+from argparse import ArgumentParser
+
+parser = ArgumentParser()
+parser.add_argument('-n', '--n_jobs', type=int,
+                    default=1, help='Number of threads to run per process')
+parser.add_argument('-q', '--queue', type=str, default='short.q',
+                    help='Name of queue to submit to')
+parser.add_argument('exec_cmd', type=str,
+                    help='Full command to execute, in quotes (")')
+
+args = parser.parse_args()
+
+submit_to_cluster(args.exec_cmd, n_jobs=args.n_jobs,
+                  queue=args.queue)

--- a/bin/submit_to_cluster
+++ b/bin/submit_to_cluster
@@ -9,10 +9,12 @@ parser.add_argument('-n', '--n_jobs', type=int,
                     default=1, help='Number of threads to run per process')
 parser.add_argument('-q', '--queue', type=str, default='short.q',
                     help='Name of queue to submit to')
+parser.add_argument('--noclean', action='store_false',
+                    help='Do not clean up the qsub submission script.')
 parser.add_argument('exec_cmd', type=str,
                     help='Full command to execute, in quotes (")')
 
 args = parser.parse_args()
 
 submit_to_cluster(args.exec_cmd, n_jobs=args.n_jobs,
-                  queue=args.queue)
+                  queue=args.queue, cleanup=args.noclean)

--- a/stormdb/process.py
+++ b/stormdb/process.py
@@ -379,7 +379,7 @@ class Maxfilter():
         self.info['cmd'] += [cmd]
         self.info['io_mapping'] += [dict(input=in_fname, output=out_fname)]
 
-    def submit_to_cluster(self, n_jobs=1, fake=False, submit_script=None):
+    def submit_to_cluster(self, n_jobs=1, fake=False):
         """ Submit the command built earlier for processing on the cluster.
 
         Things to implement


### PR DESCRIPTION
I added some code to allow query via the default "localhost:10080" route when using CFIN VPN lookalike

For some reason I managed to base it on the submit_to_cluster branch (stupid). I'd like to merge this to master anyway, mostly because I can't figure out how to fix it!

@MadsJensen this will likely break `add_FS_recon`, but I'll re-insert it later once I've refactored the code as previously discussed, OK?
