### PR TITLE
SimNIBS-based head surface creation

### DIFF
--- a/stormdb/base.py
+++ b/stormdb/base.py
@@ -61,13 +61,15 @@ def mkdir_p(pth):
 
 
 def _get_unique_series(qy, series, subject, modality):
-        series = qy.filter_series(description=series, subjects=subject,
-                                  modalities=modality)
-        if len(series) == 0:
-            raise RuntimeError('No series found matching {0} for subject '
-                               '{1}'.format(series, subject))
-        elif len(series) > 1:
-            print('Multiple series match the target:')
-            print([s['seriename'] for s in series])
-            raise RuntimeError('More than one MR series found that '
-                               'matches the pattern {0}'.format(series))
+    series = qy.filter_series(description=series, subjects=subject,
+                              modalities=modality)
+    if len(series) == 0:
+        raise RuntimeError('No series found matching {0} for subject '
+                           '{1}'.format(series, subject))
+    elif len(series) > 1:
+        print('Multiple series match the target:')
+        print([s['seriename'] for s in series])
+        raise RuntimeError('More than one MR series found that '
+                           'matches the pattern {0}'.format(series))
+
+    return series

--- a/stormdb/base.py
+++ b/stormdb/base.py
@@ -5,6 +5,7 @@ Helpers for process-tools.
 """
 
 import os
+import errno
 import inspect
 
 
@@ -46,3 +47,27 @@ def parse_arguments(func):
     kwargs = {key: val for key, val in zip(argspec.args[n_pos:],
                                            argspec.defaults)}
     return(args, kwargs)
+
+
+def mkdir_p(pth):
+    """mkdir -p"""
+    try:
+        os.makedirs(pth)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(pth):
+            pass
+        else:
+            raise
+
+
+def _get_unique_series(qy, series, subject, modality):
+        series = qy.filter_series(description=series, subjects=subject,
+                                  modalities=modality)
+        if len(series) == 0:
+            raise RuntimeError('No series found matching {0} for subject '
+                               '{1}'.format(series, subject))
+        elif len(series) > 1:
+            print('Multiple series match the target:')
+            print([s['seriename'] for s in series])
+            raise RuntimeError('More than one MR series found that '
+                               'matches the pattern {0}'.format(series))

--- a/stormdb/base.py
+++ b/stormdb/base.py
@@ -60,16 +60,16 @@ def mkdir_p(pth):
             raise
 
 
-def _get_unique_series(qy, series, subject, modality):
-    series = qy.filter_series(description=series, subjects=subject,
+def _get_unique_series(qy, series_name, subject, modality):
+    series = qy.filter_series(description=series_name, subjects=subject,
                               modalities=modality)
     if len(series) == 0:
         raise RuntimeError('No series found matching {0} for subject '
-                           '{1}'.format(series, subject))
+                           '{1}'.format(series_name, subject))
     elif len(series) > 1:
         print('Multiple series match the target:')
         print([s['seriename'] for s in series])
         raise RuntimeError('More than one MR series found that '
-                           'matches the pattern {0}'.format(series))
+                           'matches the pattern {0}'.format(series_name))
 
     return series

--- a/stormdb/cluster.py
+++ b/stormdb/cluster.py
@@ -375,7 +375,7 @@ class ClusterBatch(object):
 
     @property
     def verbose(self):
-        if self.logger.getLevel() > logging.DEBUG:
+        if self.logger.level > logging.DEBUG:
             return False
         else:
             return True

--- a/stormdb/process/__init__.py
+++ b/stormdb/process/__init__.py
@@ -8,3 +8,4 @@
 from .maxfilter import Maxfilter
 from .mne_python import MNEPython
 from .freesurfer import Freesurfer
+from .simnibs import SimNIBS

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -169,7 +169,9 @@ class SimNIBS(ClusterBatch):
                               'it instead of re-converting.'.format(mri))
                     else:
                         warn('Some input files already exist in {:s}; these '
-                             'will be used instead of re-converting.')
+                             'will be used instead of re-converting.'
+                             .format(nii_path))
+
             if mri is not None:
                 mr_inputs_str += ' ' + mri
 

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -145,7 +145,8 @@ class SimNIBS(ClusterBatch):
         # build directive string
         directives_str = ' --' + ' --'.join(directive)
 
-        mr_inputs = (t1_fs, t2_hb, t1_hb, t2_fs)  # fixed order!
+        # mri2mesh assumes following fixed order!
+        mr_inputs = (t1_hb, t1_fs, t2_hb, t2_fs)
         mr_inputs_str = ''
         for mri in mr_inputs:
             if mri is not None and '/' not in mri and '.nii' not in mri:

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -53,7 +53,7 @@ class SimNIBS(ClusterBatch):
     info : dict
         See `SimNIBS().info.keys()` for contents.
     """
-    def __init__(self, proj_name, output_dir=None, verbose=False):
+    def __init__(self, proj_name=None, output_dir=None, verbose=False):
         super(SimNIBS, self).__init__(proj_name, verbose=verbose)
 
         if output_dir is None:
@@ -68,14 +68,14 @@ class SimNIBS(ClusterBatch):
         else:
             if not output_dir.startswith('/'):
                 # the path can be _relative_ to the project dir
-                output_dir = os.path.join('/projects', proj_name,
+                output_dir = os.path.join('/projects', self.proj_name,
                                           output_dir)
 
         enforce_path_exists(output_dir)
 
+        self.info = dict(valid_subjects=Query(proj_name).get_subjects())
         self.info.update(output_dir=output_dir)
         self.verbose = verbose
-        self.info = dict(valid_subjects=Query(proj_name).get_subjects())
 
     def mri2mesh(self, subject, t1_fs=None, t2_hb=None,
                  directive=['brain', 'subcort', 'head'],
@@ -127,9 +127,7 @@ class SimNIBS(ClusterBatch):
         mr_inputs = (t1_fs, t2_hb, t1_hb, t2_fs)  # fixed order!
         mr_inputs_str = ''
         for mri in mr_inputs:
-            if mri is not None and not os.path.isfile(mri):
-                raise IOError('Input file {:s} missing!'.format(mri))
-            elif '/' not in mri and '.nii' not in mri:
+            if mri is not None and '/' not in mri and '.nii' not in mri:
                 series = _get_unique_series(Query(self.proj_name), mri,
                                             subject, 'MR')
                 dcm = os.path.join(series[0]['path'], series[0]['files'][0])

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -220,9 +220,9 @@ class SimNIBS(ClusterBatch):
 
         meshfix_opts = ' -u 10 --vertices {:d} --fsmesh'.format(n_vertices)
         bem_dir = os.path.join(fs_dir, 'bem')
-        bem_surfaces = dict(inner_skull='tmp/csf_FS.fsmesh',
-                            outer_skull='tmp/skull_FS.fsmesh',
-                            outer_skin='tmp/skin_FS.fsmesh')
+        bem_surfaces = dict(inner_skull='csf.stl',
+                            outer_skull='skull.stl',
+                            outer_skin='skin.stl')
         for bem_layer, surf in bem_surfaces.items():
             surf_fname = os.path.join(m2m_dir, surf)
             if not check_source_readable(surf_fname):

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -132,12 +132,15 @@ class SimNIBS(ClusterBatch):
             raise RuntimeError(
                 'Directive should be str or list of str, not '
                 '{0}'.format(type(directive)))
-        directive = [directive] if isinstance(directive, string_types)
+        if isinstance(directive, string_types):
+            directive = [directive]
 
         if t2mask and t2pial:
             raise ValueError('t2mask and t2pial cannot be used together!')
-        directive.append('t2mask') if t2mask
-        directive.append('t2pial') if t2pial
+        if t2mask:
+            directive.append('t2mask')
+        if t2pial:
+            directive.append('t2pial')
 
         # build directive string
         directives_str = ' --' + ' --'.join(directive)

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -176,7 +176,6 @@ class SimNIBS(ClusterBatch):
         # Build command
         cmd = 'mri2mesh ' + directives_str + ' ' + subject + mr_inputs_str
 
-        # NB implement working_dir-argument!
         self.add_job(cmd, queue=queue, n_threads=n_threads,
                      job_name='mri2mesh', working_dir=self.info['output_dir'])
 

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -220,9 +220,9 @@ class SimNIBS(ClusterBatch):
 
         meshfix_opts = ' -u 10 --vertices {:d} --fsmesh'.format(n_vertices)
         bem_dir = os.path.join(fs_dir, 'bem')
-        bem_surfaces = dict(inner_skull='csf.stl',
-                            outer_skull='skull.stl',
-                            outer_skin='skin.stl')
+        bem_surfaces = dict(inner_skull='tmp/csf_FS.fsmesh',
+                            outer_skull='tmp/skull_FS.fsmesh',
+                            outer_skin='tmp/skin_FS.fsmesh')
         for bem_layer, surf in bem_surfaces.items():
             surf_fname = os.path.join(m2m_dir, surf)
             if not check_source_readable(surf_fname):

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -184,6 +184,7 @@ class SimNIBS(ClusterBatch):
                 nii_path = os.path.join(self.info['output_dir'], 'nifti',
                                         subject)
                 mkdir_p(nii_path)
+                mri = series[0]['seriename']  # in case wildcards were used
                 mri = os.path.join(nii_path, mri + '.nii.gz')
                 if not os.path.isfile(mri):  # if exists, don't redo!
                     self.logger.info('Converting DICOM to Nifti, this will '
@@ -210,8 +211,8 @@ class SimNIBS(ClusterBatch):
         # Build command
         cmd = 'mri2mesh ' + directives_str + ' ' + subject + mr_inputs_str
 
-        self.add_job(cmd, **job_options,
-                     job_name='mri2mesh', working_dir=self.info['output_dir'])
+        self.add_job(cmd, working_dir=self.info['output_dir'],
+                     job_name='mri2mesh', **job_options)
 
     def create_bem_surfaces(self, subject, n_vertices=5120,
                             analysis_name=None, queue='short.q',

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -238,9 +238,9 @@ class SimNIBS(ClusterBatch):
             xfm = os.path.join(m2m_dir, 'tmp', 'unity.xfm')
 
             cmds += ['mris_transform --dst {xv:s} --src {xv:s} '
-                     '{bfn:s}.fsmesh {xfm:s} {bfn}.surf'
+                    '{bfn:s}.fsmesh {xfm:s} {bfn:s}.surf'
                      .format(xv=xfm_volume, bfn=bem_fname, xfm=xfm)]
-            cmds += ['mv rh.{bfn}.surf {bfn}.surf']
+            cmds += ['rm {bfn:s}.fsmesh'.format(bfn=bem_fname)]
 
             cmd = ';'.join(cmds)
             self.add_job(cmd, queue=queue, n_threads=n_threads,

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -144,10 +144,11 @@ class SimNIBS(ClusterBatch):
                     warn('The file {:s} already exists: will use '
                          'it instead of re-converting.'.format(mri))
 
-            mr_inputs_str += ' ' + mri if mri is not None
+            if mri is not None:
+                mr_inputs_str += ' ' + mri
 
         # Build command
-        cmd = 'mri2mesh ' + directives_str + mr_inputs_str
+        cmd = 'mri2mesh ' + directives_str + ' ' + subject + mr_inputs_str
 
         # NB implement working_dir-argument!
         self.add_job(cmd, queue=queue, n_threads=n_threads,

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -219,8 +219,12 @@ class SimNIBS(ClusterBatch):
             enforce_path_exists(fs_dir)
             enforce_path_exists(m2m_dir)
         except IOError as m2m_err:
-            raise RuntimeError(
-                m2m_err + ' Failed to find accessible mri2mesh-folders')
+            msg = ('{0}\nFailed to find accessible mri2mesh-folders; '
+                   'did it complete successfully?'.format(m2m_err))
+            if len(suffix) > 0:
+                msg += ('\nPlease also check that the analysis_name is '
+                        'correct: {0}'.format(analysis_name))
+            raise RuntimeError(msg)
 
         meshfix_opts = ' -u 10 --vertices {:d} --fsmesh'.format(n_vertices)
         bem_dir = os.path.join(fs_dir, 'bem')

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -179,7 +179,6 @@ class SimNIBS(ClusterBatch):
         self.add_job(cmd, queue=queue, n_threads=n_threads,
                      job_name='mri2mesh', working_dir=self.info['output_dir'])
 
-
 # def make_symbolic_links(subject, subjects_dir):
 #     """Make symblic links between FS dir and subjects_dir.
 #     Parameters

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -166,7 +166,7 @@ class SimNIBS(ClusterBatch):
                 self._joblist = []  # evicerate on error
                 raise
 
-        self.logger.info('{} jobs created Successfully, ready to submit.'
+        self.logger.info('{} jobs created successfully, ready to submit.'
                          .format(len(self._joblist)))
 
     def _mri2mesh(self, subject, t1_fs='*t1*', t2_hb='*t2*',
@@ -190,7 +190,8 @@ class SimNIBS(ClusterBatch):
                     .format(link_to_fs_dir, subject))
             fs_dir, m2m_dir = self._mri2mesh_output_dirs(subject,
                                                          analysis_name)
-            link_cmd = 'ln -s {} {}'.format(fs_dir, link_to_fs_dir)
+            link_name = os.path.join(link_to_fs_dir, subject)
+            link_cmd = 'ln -s {} {}'.format(fs_dir, link_name)
 
         if not isinstance(directives, (string_types, list)):
             raise RuntimeError(

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -67,7 +67,8 @@ class SimNIBS(ClusterBatch):
     Attributes
     ----------
     info : dict
-        See `SimNIBS().info.keys()` for contents.
+        'valid_subjects': list of subjects with MR-modality
+        'output_dir': SimNIBS output directory
     """
     def __init__(self, proj_name=None, output_dir=None, verbose=False):
         super(SimNIBS, self).__init__(proj_name, verbose=verbose)
@@ -86,8 +87,13 @@ class SimNIBS(ClusterBatch):
 
         enforce_path_exists(output_dir)
 
-        self.info = dict(valid_subjects=Query(proj_name).get_subjects())
-        self.info.update(output_dir=output_dir)
+        valid_subjects = Query(proj_name).get_subjects(has_modality='MR')
+        if len(valid_subjects) == 0:
+            raise RuntimeError(
+                'No subjects with MR-modality found in {}!'
+                .format(self.proj_name))
+        self.info = dict(valid_subjects=valid_subjects,
+                         output_dir=output_dir)
         self.verbose = verbose
 
     def mri2mesh(self, subject, t1_fs='*t1*', t2_hb='*t2*',

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -81,10 +81,7 @@ class SimNIBS(ClusterBatch):
                     'SN_SUBJECT_DIR environment variable. The directory must '
                     'exist.')
         else:
-            if not output_dir.startswith('/'):
-                # the path can be _relative_ to the project dir
-                output_dir = os.path.join('/projects', self.proj_name,
-                                          output_dir)
+            output_dir = self._get_absolute_path(output_dir)
 
         enforce_path_exists(output_dir)
 
@@ -169,6 +166,9 @@ class SimNIBS(ClusterBatch):
                 self._joblist = []  # evicerate on error
                 raise
 
+        self.logger.info('{} jobs created Successfully, ready to submit.'
+                         .format(len(self._joblist)))
+
     def _mri2mesh(self, subject, t1_fs='*t1*', t2_hb='*t2*',
                   directives=['brain', 'subcort', 'head'],
                   analysis_name=None, t2mask=False, t2pial=False,
@@ -181,6 +181,7 @@ class SimNIBS(ClusterBatch):
                 'Subject {0} not found in database!'.format(subject))
 
         if isinstance(link_to_fs_dir, string_types):
+            link_to_fs_dir = self._get_absolute_path(link_to_fs_dir)
             enforce_path_exists(link_to_fs_dir)
             if os.path.exists(os.path.join(link_to_fs_dir, subject)):
                 raise RuntimeError(
@@ -331,3 +332,10 @@ class SimNIBS(ClusterBatch):
                                'm2m_' + subject + suffix)
 
         return fs_dir, m2m_dir
+
+    def _get_absolute_path(self, output_dir):
+        if not output_dir.startswith('/'):
+            # the path can be _relative_ to the project dir
+            output_dir = os.path.join('/projects', self.proj_name,
+                                      output_dir)
+        return output_dir

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -134,7 +134,7 @@ class SimNIBS(ClusterBatch):
                 nii_path = os.path.join(self.info['output_dir'], 'nifti',
                                         subject)
                 mkdir_p(nii_path)
-                mri = os.path.join(nii_path, mri + '.nii.gz')
+                mri = os.path.join(nii_path, subject + '_' + mri + '.nii.gz')
                 if not os.path.isfile(mri):  # if exists, don't redo!
                     self.logger.info('Converting DICOM to Nifti, this will '
                                      'take about 15 seconds...')
@@ -144,7 +144,7 @@ class SimNIBS(ClusterBatch):
                     warn('The file {:s} already exists: will use '
                          'it instead of re-converting.'.format(mri))
 
-            mr_inputs_str += ' ' + mri
+            mr_inputs_str += ' ' + mri if mri is not None
 
         # Build command
         cmd = 'mri2mesh ' + directives_str + mr_inputs_str

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -238,7 +238,7 @@ class SimNIBS(ClusterBatch):
             xfm = os.path.join(m2m_dir, 'tmp', 'unity.xfm')
 
             cmds += ['mris_transform --dst {xv:s} --src {xv:s} '
-                    '{bfn:s}.fsmesh {xfm:s} {bfn:s}.surf'
+                     '{bfn:s}.fsmesh {xfm:s} {bfn:s}.surf'
                      .format(xv=xfm_volume, bfn=bem_fname, xfm=xfm)]
             cmds += ['rm {bfn:s}.fsmesh'.format(bfn=bem_fname)]
 

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -1,0 +1,120 @@
+from .base import check_destination_writable, check_source_readable
+from ..cluster import ClusterBatch
+
+
+class SimNIBS(ClusterBatch):
+    """Clusterised SimNIBS pipeline.
+
+       http://www.simnibs.de
+    """
+    def __init__(self, proj_name, bad=[], verbose=True):
+        super(SimNIBS, self).__init__(proj_name)
+
+        self.info = dict(bad=bad, io_mapping=[])
+
+    def build_cmd(self, t1_fs=None, t2_hb=None, t1_hb=None, t2_fs=None,
+                  in_fname, out_fname, origin='0 0 40',
+                  frame='head', bad=None, autobad='off', skip=None,
+                  force=False, st=False, st_buflen=16.0,
+                  st_corr=0.96, trans=None, movecomp=False,
+                  headpos=False, hp=None, hpistep=None,
+                  hpisubt=None, hpicons=True, linefreq=None,
+                  cal=None, ctc=None, mx_args='',
+                  maxfilter_bin='/neuro/bin/util/maxfilter',
+                  logfile=None, n_threads=4):
+
+        """Build a NeuroMag MaxFilter command for later execution.
+
+        See the Maxfilter manual for details on the different options!
+
+        Things to implement
+        * check that cal-file matches date in infile!
+        * check that maxfilter binary is OK
+
+        Parameters
+        ----------
+        t1_fs : str
+            Input file name
+        out_fname : str
+            Output file name
+        n_threads : int
+            Number of parallel threads to execute on (default: 4)
+    """
+
+
+def make_symbolic_links(subject, subjects_dir):
+    """Make symblic links between FS dir and subjects_dir.
+    Parameters
+    ----------
+    fname : string
+        The name of the subject to create for
+    subjects_dir : string
+        The subjects dir for FreeSurfer
+    """
+
+    make_links = "ln -s fs_%s/* ." % subject[:4]
+    os.chdir(fs_subjects_dir + subject[:4])
+    subprocess.call([cmd, "1", make_links])
+
+
+def convert_surfaces(subject, subjects_dir):
+    """Convert the SimNIBS surface to FreeSurfer surfaces.
+    Parameters
+    ----------
+    subject : string
+       The name of the subject
+    subjects_dir : string
+        The subjects dir for FreeSurfer
+    """
+    convert_csf = "meshfix csf.stl -u 10 --vertices 4098 --fsmesh"
+    convert_skull = "meshfix skull.stl -u 10 --vertices 4098 --fsmesh"
+    convert_skin = "meshfix skin.stl -u 10 --vertices 4098 --fsmesh"
+
+    os.chdir(fs_subjects_dir + subject[:4] + "/m2m_%s" % subject[:4])
+    subprocess.call([cmd, "1", convert_csf])
+    subprocess.call([cmd, "1", convert_skull])
+    subprocess.call([cmd, "1", convert_skin])
+
+
+def copy_surfaces(subject, subjects_dir):
+    """Copy the converted FreeSurfer surfaces to the bem dir.
+    Parameters
+    ----------
+    subject : string
+       The name of the subject
+    subjects_dir : string
+        The subjects dir for FreeSurfer
+    """
+    os.chdir(fs_subjects_dir + subject[:4] + "/m2m_%s" % subject[:4])
+    copy_inner_skull = "cp -f csf_fixed.fsmesh " + subjects_dir + \
+                       "/%s/bem/inner_skull.surf" % subject[:4]
+    copy_outer_skull = "cp -f skull_fixed.fsmesh " + subjects_dir + \
+                       "/%s/bem/outer_skull.surf" % subject[:4]
+    copy_outer_skin = "cp -f skin_fixed.fsmesh " + subjects_dir + \
+                       "/%s/bem/outer_skin.surf" % subject[:4]
+
+    subprocess.call([cmd, "1", copy_inner_skull])
+    subprocess.call([cmd, "1", copy_outer_skull])
+    subprocess.call([cmd, "1", copy_outer_skin])
+
+    os.chdir(fs_subjects_dir + subject[:4] + "/bem")
+    convert_skin_to_head = "mne_surf2bem --surf outer_skin.surf --fif %s-head.fif --id 4" % subject[:4]
+    subprocess.call([cmd, "1", convert_skin_to_head])
+
+
+def setup_mne_c_forward(subject):
+    setup_forward = "mne_setup_forward_model --subject %s --surf --ico -6" %subject[:4]
+    subprocess.call([cmd, "1", setup_forward])
+
+
+for subject in included_subjects[3:5]:
+    make_symbolic_links(subject, fs_subjects_dir)
+
+for subject in included_subjects[3:5]:
+    convert_surfaces(subject, fs_subjects_dir)
+
+for subject in included_subjects[3:5]:
+    copy_surfaces(subject, fs_subjects_dir)
+
+for subject in included_subjects[3:5]:
+    setup_mne_c_forward(subject)

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -230,8 +230,8 @@ class SimNIBS(ClusterBatch):
                     'Could not find surface {surf:s}; mri2mesh may have exited'
                     ' with an error, please check.'.format(surf))
             bem_fname = os.path.join(bem_dir, bem_layer)
-            cmd = 'meshfix {mfopts:s} -o {bfn:s}'.format(mfopts=meshfix_opts,
-                                                         bfn=bem_fname)
+            cmd = ('meshfix {sfn:s} {mfo:s} -o {bfn:s}'
+                   .format(sfn=surf_fname, mfo=meshfix_opts, bfn=bem_fname))
             self.add_job(cmd, queue=queue, n_threads=n_threads,
                          job_name='meshfix',
                          working_dir=self.info['output_dir'])

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -215,8 +215,12 @@ class SimNIBS(ClusterBatch):
                               'fs_' + subject + suffix)
         m2m_dir = os.path.join(self.info['output_dir'],
                                'm2m_' + subject + suffix)
-        enforce_path_exists(fs_dir)
-        enforce_path_exists(m2m_dir)
+        try:
+            enforce_path_exists(fs_dir)
+            enforce_path_exists(m2m_dir)
+        except IOError as m2m_err:
+            raise RuntimeError(
+                m2m_err + ' Failed to find accessible mri2mesh-folders')
 
         meshfix_opts = ' -u 10 --vertices {:d} --fsmesh'.format(n_vertices)
         bem_dir = os.path.join(fs_dir, 'bem')
@@ -228,7 +232,7 @@ class SimNIBS(ClusterBatch):
             if not check_source_readable(surf_fname):
                 raise RuntimeError(
                     'Could not find surface {surf:s}; mri2mesh may have exited'
-                    ' with an error, please check.'.format(surf))
+                    ' with an error, please check.'.format(surf=surf))
             bem_fname = os.path.join(bem_dir, bem_layer)
 
             cmds = ['meshfix {sfn:s} {mfo:s} -o {bfn:s}'

--- a/stormdb/process/simnibs.py
+++ b/stormdb/process/simnibs.py
@@ -230,8 +230,19 @@ class SimNIBS(ClusterBatch):
                     'Could not find surface {surf:s}; mri2mesh may have exited'
                     ' with an error, please check.'.format(surf))
             bem_fname = os.path.join(bem_dir, bem_layer)
-            cmd = ('meshfix {sfn:s} {mfo:s} -o {bfn:s}'
-                   .format(sfn=surf_fname, mfo=meshfix_opts, bfn=bem_fname))
+
+            cmds = ['meshfix {sfn:s} {mfo:s} -o {bfn:s}'
+                    .format(sfn=surf_fname, mfo=meshfix_opts, bfn=bem_fname)]
+
+            xfm_volume = os.path.join(m2m_dir, 'tmp', 'subcortical_FS.nii.gz')
+            xfm = os.path.join(m2m_dir, 'tmp', 'unity.xfm')
+
+            cmds += ['mris_transform --dst {xv:s} --src {xv:s} '
+                     '{bfn:s}.fsmesh {xfm:s} {bfn}.surf'
+                     .format(xv=xfm_volume, bfn=bem_fname, xfm=xfm)]
+            cmds += ['mv rh.{bfn}.surf {bfn}.surf']
+
+            cmd = ';'.join(cmds)
             self.add_job(cmd, queue=queue, n_threads=n_threads,
                          job_name='meshfix',
                          working_dir=self.info['output_dir'])

--- a/stormdb/process/tests/test_simnibs.py
+++ b/stormdb/process/tests/test_simnibs.py
@@ -1,0 +1,18 @@
+import os
+from stormdb.process import SimNIBS
+from nose.tools import assert_true, assert_equal, assert_raises
+
+
+proj_name = 'MEG_EEG-Training'
+test_subject_name = '0002_M55'
+t1_fs = 't1_mpr_sag_weakFS'
+t2_hb = 't2_tse_sag_HighBW'
+t1_hb = 't1_mpr_sag_HighBW'
+t2_fs = 't2_tse_sag_FS'
+output_dir = 'scratch/sn_subjects_dir'
+
+
+def test_init():
+    if 'SN_SUBJECTS_DIR' not in os.environ.keys():
+        assert_raises(ValueError, SimNIBS, proj_name)  # define outdir
+    assert_raises(IOError, SimNIBS, proj_name, output_dir='')

--- a/stormdb/process/utils.py
+++ b/stormdb/process/utils.py
@@ -1,0 +1,29 @@
+"""
+=========================
+Utility function for process-modules
+=========================
+
+"""
+# Author: Chris Bailey <cjb@cfin.au.dk>
+#
+# License: BSD (3-clause)
+import subprocess as subp
+import os
+import shutil
+import tempfile
+
+
+def convert_dicom_to_nifti(first_dicom, output_fname,
+                           converter='mri_convert'):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shutil.copytree(os.path.dirname(first_dicom), tmpdir)
+        if converter == 'mri_convert':
+            cmd = ' '.join(converter, first_dicom, output_fname)
+        else:
+            raise NotImplementedError('{:s} not known.'.format(converter))
+
+        try:
+            subp.check_output([cmd], stderr=subp.STDOUT, shell=False)
+        except subp.CalledProcessError as cpe:
+            raise RuntimeError('Conversion failed with error message: '
+                               '{:s}'.format(cpe.returncode, cpe.output))

--- a/stormdb/process/utils.py
+++ b/stormdb/process/utils.py
@@ -23,12 +23,12 @@ def convert_dicom_to_nifti(first_dicom, output_fname,
         shutil.copy(dcm, tmpdir)
 
     if converter == 'mri_convert':
-        cmd = ' '.join(converter, first_dicom, output_fname)
+        cmd = ' '.join([converter, first_dicom, output_fname])
     else:
         raise NotImplementedError('{:s} not known.'.format(converter))
 
     try:
-        subp.check_output([cmd], stderr=subp.STDOUT, shell=False)
+        subp.check_output([cmd], stderr=subp.STDOUT, shell=True)
     except subp.CalledProcessError as cpe:
         raise RuntimeError('Conversion failed with error message: '
                            '{:s}'.format(cpe.returncode, cpe.output))

--- a/stormdb/process/utils.py
+++ b/stormdb/process/utils.py
@@ -15,15 +15,16 @@ import tempfile
 
 def convert_dicom_to_nifti(first_dicom, output_fname,
                            converter='mri_convert'):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        shutil.copytree(os.path.dirname(first_dicom), tmpdir)
-        if converter == 'mri_convert':
-            cmd = ' '.join(converter, first_dicom, output_fname)
-        else:
-            raise NotImplementedError('{:s} not known.'.format(converter))
+    tmpdir = tempfile.mkdtemp()
+    shutil.copytree(os.path.dirname(first_dicom), tmpdir)
+    if converter == 'mri_convert':
+        cmd = ' '.join(converter, first_dicom, output_fname)
+    else:
+        raise NotImplementedError('{:s} not known.'.format(converter))
 
-        try:
-            subp.check_output([cmd], stderr=subp.STDOUT, shell=False)
-        except subp.CalledProcessError as cpe:
-            raise RuntimeError('Conversion failed with error message: '
-                               '{:s}'.format(cpe.returncode, cpe.output))
+    try:
+        subp.check_output([cmd], stderr=subp.STDOUT, shell=False)
+    except subp.CalledProcessError as cpe:
+        raise RuntimeError('Conversion failed with error message: '
+                           '{:s}'.format(cpe.returncode, cpe.output))
+    shutil.rmtree(tmpdir)

--- a/stormdb/process/utils.py
+++ b/stormdb/process/utils.py
@@ -11,12 +11,17 @@ import subprocess as subp
 import os
 import shutil
 import tempfile
+from glob import glob
 
 
 def convert_dicom_to_nifti(first_dicom, output_fname,
                            converter='mri_convert'):
     tmpdir = tempfile.mkdtemp()
-    shutil.copytree(os.path.dirname(first_dicom), tmpdir)
+    dicom_dir = os.path.dirname(first_dicom)
+    first_dicom = os.path.join(tmpdir, os.path.basename(first_dicom))
+    for dcm in glob(os.path.join(dicom_dir, '*.*')):
+        shutil.copy(dcm, tmpdir)
+
     if converter == 'mri_convert':
         cmd = ' '.join(converter, first_dicom, output_fname)
     else:


### PR DESCRIPTION
Implement `stormdb.process SimNIBS` for running on the cluster.

Example 1: Create the meshes required for source space analysis of MEG,
based on a fat-saturated T1 and high bandwidth T2 (note use of wildcards)
```python
        >>> from stormdb.process import SimNIBS  # doctest: +SKIP
        >>> sn = SimNIBS(output_dir='scratch/sn_subjects_dir')  # doctest: +SKIP
        >>> sn.mri2mesh('0002_M55', t1_fs='*t1*FS',
                        t2_hb='*t2*H*')  # doctest: +SKIP
        >>> sn.submit()  # doctest: +SKIP
```
Example 2: Once the meshes have been calculated, convert them to lower-
resolution surfaces suitable for BEM-based forward modeling
```python
        >>> from stormdb.process import SimNIBS  # doctest: +SKIP
        >>> sn = SimNIBS(output_dir='scratch/sn_subjects_dir')  # doctest: +SKIP
        >>> sn.create_bem_surfaces('0002_M55', t1_fs='*t1*FS',
                                   t2_hb='*t2*H*')  # doctest: +SKIP
        >>> sn.submit()  # doctest: +SKIP
```