### PR TITLE
Fix fs slow convert 33

### DIFF
--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -64,7 +64,7 @@ class Freesurfer(ClusterBatch):
         else:
             if not subjects_dir.startswith('/'):
                 # the path can be _relative_ to the project dir
-                subjects_dir = os.path.join('/projects', proj_name,
+                subjects_dir = os.path.join('/projects', self.proj_name,
                                             subjects_dir)
 
         enforce_path_exists(subjects_dir)

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -116,10 +116,11 @@ class Freesurfer(ClusterBatch):
         if subject not in self.info['valid_subjects']:
             raise RuntimeError(
                 'Subject {0} not found in database!'.format(subject))
-            if analysis_name is not None:
-                if not isinstance(analysis_name, string_types):
-                    raise ValueError('Analysis name suffix must be a string.')
-                subject += analysis_name
+
+        if analysis_name is not None:
+            if not isinstance(analysis_name, string_types):
+                raise ValueError('Analysis name suffix must be a string.')
+            subject += analysis_name
         cur_subj_dir = os.path.join(self.info['subjects_dir'], subject)
 
         # Build command, force subjects_dir on cluster nodes


### PR DESCRIPTION
Convert from dicom to mgz before running rest of recon-all. Not very resource-consuming, saves about 20-30 mins due to weird incompatibility between BeeGFS (file system on hyades where `raw` is located) and `mri_info` called by `mri_convert`.

Closes #33 
