### PR TITLE
enable freesurfer runs on multiple subs

### DIFF
--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -169,15 +169,15 @@ class Freesurfer(ClusterBatch):
         # has DICOM conversion been performed?
         if not os.path.exists(cur_subj_dir) or not check_source_readable(
                 os.path.join(cur_subj_dir, 'mri', 'orig', '001.mgz')):
-            self.logger.info('Initialising freesurfer folder structure and '
-                             'converting DICOM files; this should take about '
-                             '15 seconds...')
             if t1_series is None:
                 if 't1_series' not in self.info.keys():
                     raise RuntimeError('Name of T1 series must be defined!')
                 else:
                     t1_series = self.info['t1_series']
 
+            self.logger.info('Initialising freesurfer folder structure and '
+                             'converting DICOM files; this should take about '
+                             '15 seconds...')
             series = _get_unique_series(Query(self.proj_name), t1_series,
                                         subject, 'MR')
             tmpdir = make_copy_of_dicom_dir(series[0]['path'])


### PR DESCRIPTION
Make `Freesurfer` behave like `SimNIBS`: allow specifying `'all'` or list of subjects to `recon-all`

```python
    Example 1: Run `recon-all -all` on all subjects in the database that
    include a study with an MR-modality present. Ensure that each subject
    has an MR-series matching the wildcard '*t1*mpr*'. Also use the default
    option '-3T' for non-uniformity correction at 3T. The jobs will be
    submitted to 'long.q' and run on 1 thread per job (defaults).
        >>> from stormdb.process import Freesurfer  # doctest: +SKIP
        >>> fs = Freesurfer(subjects_dir='scratch/fs_subjects_dir',
                            t1_series='*t1*mpr*')  # doctest: +SKIP
        >>> fs.recon_all('all')  # doctest: +SKIP
        >>> fs.submit()  # doctest: +SKIP
```