### PR TITLE
FLASH- and watershed-based BEM surfaces

### DIFF
--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -56,7 +56,7 @@ def run():
                       help="Subject name", default=None)
     parser.add_option("-d", "--subjects-dir", dest="subjects_dir",
                       help="Subjects directory", default=None)
-    parser.add_option("-e", "--n_echos", dest="n_echos",
+    parser.add_option("-e", "--n_echos", dest="n_echos", type=int,
                       help="Number of echos (default: 8)", default=8)
     parser.add_option("-3", "--noflash30", dest="noflash30",
                       action="store_true", default=True,

--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -83,7 +83,7 @@ def run():
 
     flash_dir = op.join(os.getcwd(), 'flash05')
     n_echos = len([name for name in os.listdir(flash_dir) if
-        op.isdir(op.join(flash_dir, name))])
+                  op.isdir(op.join(flash_dir, name))])
 
     convert_flash_mris_cfin(subject=subject, subjects_dir=subjects_dir,
                             flash30=flash30, n_echos=n_echos, unwarp=unwarp)

--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -36,7 +36,7 @@ Before running this script do the following:
 
 Example usage:
 
-$ mne flash_bem --subject sample
+$ cfin_flash_bem --subject sample
 """
 from __future__ import print_function
 
@@ -46,50 +46,42 @@ import os
 import os.path as op
 from mne.bem import make_flash_bem
 from stormdb.process import convert_flash_mris_cfin
+from argparse import ArgumentParser
 
+parser = ArgumentParser()
 
-def run():
-    """Run command."""
-    from mne.commands.utils import get_optparser
+parser.add_argument("-s", "--subject", dest="subject",
+                  help="Subject name", default=None)
+parser.add_argument("-d", "--subjects-dir", dest="subjects_dir",
+                  help="Subjects directory", default=None)
+parser.add_argument("-3", "--noflash30", dest="noflash30",
+                  action="store_true", default=False,
+                  help=("Skip the 30-degree flip angle data"),)
+parser.add_argument("-u", "--unwarp", dest="unwarp",
+                  action="store_true", default=False,
+                  help=("Run grad_unwarp with -unwarp <type> option on "
+                        "each of the converted data sets"))
+parser.add_argument("-o", "--overwrite", dest="overwrite",
+                  action="store_true", default=False,
+                  help="Write over existing .surf files in bem folder")
 
-    parser = get_optparser(__file__)
+options = parser.parse_args()
 
-    parser.add_option("-s", "--subject", dest="subject",
-                      help="Subject name", default=None)
-    parser.add_option("-d", "--subjects-dir", dest="subjects_dir",
-                      help="Subjects directory", default=None)
-    parser.add_option("-3", "--noflash30", dest="noflash30",
-                      action="store_true", default=False,
-                      help=("Skip the 30-degree flip angle data"),)
-    parser.add_option("-u", "--unwarp", dest="unwarp",
-                      action="store_true", default=False,
-                      help=("Run grad_unwarp with -unwarp <type> option on "
-                            "each of the converted data sets"))
-    parser.add_option("-o", "--overwrite", dest="overwrite",
-                      action="store_true", default=False,
-                      help="Write over existing .surf files in bem folder")
+subject = options.subject
+subjects_dir = options.subjects_dir
+flash30 = not options.noflash30
+unwarp = options.unwarp
+overwrite = options.overwrite
 
-    options, args = parser.parse_args()
+if options.subject is None:
+    parser.print_help()
+    raise RuntimeError('The subject argument must be set')
 
-    subject = options.subject
-    subjects_dir = options.subjects_dir
-    flash30 = not options.noflash30
-    unwarp = options.unwarp
-    overwrite = options.overwrite
+flash_dir = op.join(os.getcwd(), 'flash05')
+n_echos = len([name for name in os.listdir(flash_dir) if
+              op.isdir(op.join(flash_dir, name))])
 
-    if options.subject is None:
-        parser.print_help()
-        raise RuntimeError('The subject argument must be set')
-
-    flash_dir = op.join(os.getcwd(), 'flash05')
-    n_echos = len([name for name in os.listdir(flash_dir) if
-                  op.isdir(op.join(flash_dir, name))])
-
-    convert_flash_mris_cfin(subject=subject, subjects_dir=subjects_dir,
-                            flash30=flash30, n_echos=n_echos, unwarp=unwarp)
-    make_flash_bem(subject=subject, subjects_dir=subjects_dir,
-                   overwrite=overwrite, show=False, flash_path=None)
-
-is_main = (__name__ == '__main__')
-if is_main:
-    run()
+convert_flash_mris_cfin(subject=subject, subjects_dir=subjects_dir,
+                        flash30=flash30, n_echos=n_echos, unwarp=unwarp)
+make_flash_bem(subject=subject, subjects_dir=subjects_dir,
+               overwrite=overwrite, show=False, flash_path=None)

--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -88,7 +88,7 @@ def run():
     convert_flash_mris_cfin(subject=subject, subjects_dir=subjects_dir,
                             flash30=flash30, n_echos=n_echos, unwarp=unwarp)
     make_flash_bem(subject=subject, subjects_dir=subjects_dir,
-                   overwrite=overwrite, show=False, flash_path='.')
+                   overwrite=overwrite, show=False, flash_path=None)
 
 is_main = (__name__ == '__main__')
 if is_main:

--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -59,7 +59,7 @@ def run():
     parser.add_option("-e", "--n_echos", dest="n_echos",
                       help="Number of echos (default: 8)", default=8)
     parser.add_option("-3", "--noflash30", dest="noflash30",
-                      action="store_true", default=False,
+                      action="store_true", default=True,
                       help=("Skip the 30-degree flip angle data"),)
     parser.add_option("-u", "--unwarp", dest="unwarp",
                       action="store_true", default=False,

--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""Create 3-layer BEM model from Flash MRI images, with CFIN edits.
+
+NB! This is a slightly modified and "clusterised" version of that found in
+mne-python/mne/commands, all credits go there.
+
+This program assumes that FreeSurfer and MNE are installed and
+sourced properly.
+
+This function extracts the BEM surfaces (outer skull, inner skull, and
+outer skin) from multiecho FLASH MRI data with spin angles of 5 and 30
+degrees. The multiecho FLASH data are inputted in DICOM format.
+This function assumes that the Freesurfer segmentation of the subject
+has been completed. In particular, the T1.mgz and brain.mgz MRI volumes
+should be, as usual, in the subject's mri directory.
+
+Before running this script do the following:
+(unless the --noconvert option is specified)
+
+    1. Copy all of your FLASH images in a single directory <source> and
+       create a directory <dest> to hold the output of mne_organize_dicom
+    2. cd to <dest> and run
+       $ mne_organize_dicom <source>
+       to create an appropriate directory structure
+    3. Create symbolic links to make flash05 and flash30 point to the
+       appropriate series:
+       $ ln -s <FLASH 5 series dir> flash05
+       $ ln -s <FLASH 30 series dir> flash30
+       Some partition formats (e.g. FAT32) do not support symbolic links.
+       In this case, copy the file to the appropriate series:
+       $ cp <FLASH 5 series dir> flash05
+       $ cp <FLASH 30 series dir> flash30
+    4. cd to the directory where flash05 and flash30 links are
+    5. Set SUBJECTS_DIR and SUBJECT environment variables appropriately
+    6. Run this script
+
+Example usage:
+
+$ mne flash_bem --subject sample
+"""
+from __future__ import print_function
+
+# Authors: Lorenzo De Santis
+
+from mne.bem import make_flash_bem
+from stormdb.process import convert_flash_mris_cfin
+
+
+def run():
+    """Run command."""
+    from mne.commands.utils import get_optparser
+
+    parser = get_optparser(__file__)
+
+    parser.add_option("-s", "--subject", dest="subject",
+                      help="Subject name", default=None)
+    parser.add_option("-d", "--subjects-dir", dest="subjects_dir",
+                      help="Subjects directory", default=None)
+    parser.add_option("-e", "--n_echos", dest="n_echos",
+                      help="Number of echos (default: 8)", default=8)
+    parser.add_option("-3", "--noflash30", dest="noflash30",
+                      action="store_true", default=False,
+                      help=("Skip the 30-degree flip angle data"),)
+    parser.add_option("-u", "--unwarp", dest="unwarp",
+                      action="store_true", default=False,
+                      help=("Run grad_unwarp with -unwarp <type> option on "
+                            "each of the converted data sets"))
+    parser.add_option("-o", "--overwrite", dest="overwrite",
+                      action="store_true", default=False,
+                      help="Write over existing .surf files in bem folder")
+
+    options, args = parser.parse_args()
+
+    subject = options.subject
+    subjects_dir = options.subjects_dir
+    n_echos = options.n_echos
+    flash30 = not options.noflash30
+    unwarp = options.unwarp
+    overwrite = options.overwrite
+
+    if options.subject is None:
+        parser.print_help()
+        raise RuntimeError('The subject argument must be set')
+
+    convert_flash_mris_cfin(subject=subject, subjects_dir=subjects_dir,
+                            flash30=flash30, n_echos=n_echos, unwarp=unwarp)
+    make_flash_bem(subject=subject, subjects_dir=subjects_dir,
+                   overwrite=overwrite, show=False, flash_path='.')
+
+is_main = (__name__ == '__main__')
+if is_main:
+    run()

--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -59,7 +59,7 @@ def run():
     parser.add_option("-d", "--subjects-dir", dest="subjects_dir",
                       help="Subjects directory", default=None)
     parser.add_option("-3", "--noflash30", dest="noflash30",
-                      action="store_true", default=True,
+                      action="store_true", default=False,
                       help=("Skip the 30-degree flip angle data"),)
     parser.add_option("-u", "--unwarp", dest="unwarp",
                       action="store_true", default=False,

--- a/bin/cfin_flash_bem
+++ b/bin/cfin_flash_bem
@@ -42,6 +42,8 @@ from __future__ import print_function
 
 # Authors: Lorenzo De Santis
 
+import os
+import os.path as op
 from mne.bem import make_flash_bem
 from stormdb.process import convert_flash_mris_cfin
 
@@ -56,8 +58,6 @@ def run():
                       help="Subject name", default=None)
     parser.add_option("-d", "--subjects-dir", dest="subjects_dir",
                       help="Subjects directory", default=None)
-    parser.add_option("-e", "--n_echos", dest="n_echos", type=int,
-                      help="Number of echos (default: 8)", default=8)
     parser.add_option("-3", "--noflash30", dest="noflash30",
                       action="store_true", default=True,
                       help=("Skip the 30-degree flip angle data"),)
@@ -73,7 +73,6 @@ def run():
 
     subject = options.subject
     subjects_dir = options.subjects_dir
-    n_echos = options.n_echos
     flash30 = not options.noflash30
     unwarp = options.unwarp
     overwrite = options.overwrite
@@ -81,6 +80,10 @@ def run():
     if options.subject is None:
         parser.print_help()
         raise RuntimeError('The subject argument must be set')
+
+    flash_dir = op.join(os.getcwd(), 'flash05')
+    n_echos = len([name for name in os.listdir(flash_dir) if
+        op.isdir(op.join(flash_dir, name))])
 
     convert_flash_mris_cfin(subject=subject, subjects_dir=subjects_dir,
                             flash30=flash30, n_echos=n_echos, unwarp=unwarp)

--- a/bin/cfin_watershed_bem
+++ b/bin/cfin_watershed_bem
@@ -1,0 +1,229 @@
+#!/bin/sh
+#
+#   NB: This is an ever-so-slight modification of mne_watershed_bem,
+#   copied here to ensure it remains available. Changes include:
+#     * gcaatlas-option finds atlas name in Freesurfer (not hard-coded)
+#     * allow specifying SUBJECTS_DIR on command line
+#   19 Jan 2017, cjb
+#
+#	Create BEM surfaces using the watershed algorithm included with
+#       FreeSurfer
+#
+#       Copyright 2006
+#
+#       Matti Hamalainen
+#       Athinoula A. Martinos Center for Biomedical Imaging
+#       Massachusetts General Hospital
+#       Charlestown, MA, USA
+#
+#       $Id: mne_watershed_bem 3391 2012-11-30 21:13:09Z msh $
+#
+cleanup()
+{
+	echo "Temporary files removed."
+}
+usage()
+{
+	echo "usage: $0 [options]"
+	echo 
+	echo "     --overwrite             (to write over existing files)"
+	echo "     --subject subject       (defaults to SUBJECT environment variable)"
+	echo "     --sd subjects_dir       (defaults to SUBJECTS_DIR environment variable)"
+	echo "     --volume  name          (defaults to T1)"
+	echo "     --atlas                 specify the --atlas option for mri_watershed"
+        echo "     --gcaatlas              use the subcortical atlas"
+        echo "     --preflood number       change the preflood height"
+	echo
+	echo "Minimal invocation:"
+	echo
+	echo "$0                      (SUBJECT environment variable set)"
+	echo "$0 --subject subject    (define subject on the command line)"
+	echo 
+}
+#
+if [ ! "$FREESURFER_HOME" ] ; then 
+    echo "The FreeSurfer environment needs to be set up for this script"
+    exit 1
+fi
+if [ ! "$MNE_ROOT" ]
+then
+    echo "MNE_ROOT environment variable is not set"
+    exit 1
+fi
+force=false
+atlas=
+gcaatlas=false
+preflood=
+volume=T1
+#
+#	Parse the options
+#
+while [ $# -gt 0 ]
+do
+	case "$1" in  
+	--subject) 
+		shift
+		if [ $# -eq 0 ]
+		then
+			echo "--subject: argument required."
+			exit 1
+		else
+			export SUBJECT=$1
+		fi
+		;;
+	--sd) 
+		shift
+		if [ $# -eq 0 ]
+		then
+			echo "--sd: argument required."
+			exit 1
+		else
+            export SUBJECTS_DIR=$1
+		fi
+		;;
+	--volume) 
+		shift
+		if [ $# -eq 0 ]
+		then
+			echo "--volume: argument required."
+			exit 1
+		else
+			export volume=$1
+		fi
+		;;
+	--overwrite)
+		force=true
+		;;
+	--atlas)
+		atlas=-atlas
+		;;
+	--gcaatlas)
+                gcaatlas=true
+		;;
+        --preflood)
+		shift
+		if [ $# -eq 0 ]
+		then
+			echo "--preflood: argument required."
+			exit 1
+		else
+                        preflood="-h $1"
+		fi
+                ;;
+	--help)
+		usage
+		exit 1
+		;;
+	esac
+
+	shift
+done
+#
+#	Check everything is alright
+#
+if [ ! "$SUBJECT" ]
+then
+	usage
+	exit 1
+fi
+#
+if [ ! "$SUBJECTS_DIR" ]
+then
+    echo "Either specify the --sd option,"
+	echo "or set the environment variable SUBJECTS_DIR"
+	exit 1
+fi
+#
+subject_dir=$SUBJECTS_DIR/$SUBJECT
+mri_dir=$subject_dir/mri
+T1_dir=$mri_dir/$volume
+T1_mgz=$mri_dir/$volume.mgz
+bem_dir=$subject_dir/bem
+ws_dir=$subject_dir/bem/watershed
+gca_atlas=$(find $FREESURFER_HOME/average/ -name RB_all_withskull*)
+#
+# We can only set this after we know what the name of the subject is
+#
+if [ "$gcaatlas" = true ]
+then
+	atlas="-atlas -T1 -brain_atlas $gca_atlas $subject_dir/mri/transforms/talairach_with_skull.lta"
+fi
+#
+if [ ! -d $subject_dir ]
+then 
+	echo "Could not find the MRI data directory $subject_dir"
+	exit 1
+fi
+if [ ! -d $bem_dir ]
+then 
+    mkdir -p $bem_dir
+    if [ $? -ne 0 ]
+    then
+	echo "Could not create the model directory $bem_dir"
+	exit 1
+    fi
+fi
+if [ ! -d $T1_dir -a ! -f $T1_mgz ]
+then 
+    echo "Could not find the MRI data"
+    exit 1
+fi
+if [ -d $ws_dir ]
+then
+	if [ $force = "false" ]
+	then
+		echo "$ws_dir already exists. Use the --overwrite option to recreate it"
+		exit 1
+	else
+		rm -rf $ws_dir
+		if [ $? -ne 0 ]
+		then 
+			echo "Could not remove $ws_dir"
+			exit 1
+		fi
+	fi
+fi
+#
+#	Report
+#
+echo 
+echo "Running mri_watershed for BEM segmentation with the following parameters"
+echo
+echo "SUBJECTS_DIR = $SUBJECTS_DIR"
+echo "Subject      = $SUBJECT"
+echo "Result dir   = $ws_dir"
+echo
+mkdir -p $ws_dir/ws
+if [ $? -ne 0 ]
+then 
+    echo "Could not create the destination directories"
+    exit 1
+fi
+cleanup
+if [ -f $T1_mgz ]
+then
+    mri_watershed $preflood $atlas -useSRAS -surf $ws_dir/$SUBJECT $T1_mgz $ws_dir/ws
+else
+    mri_watershed $preflood $atlas -useSRAS -surf $ws_dir/$SUBJECT $T1_dir $ws_dir/ws
+fi    
+if [ $? -ne 0 ]
+then
+    exit 1
+fi
+#
+cd $ws_dir
+if [ -f $T1_mgz ] ; then
+    surfaces="${SUBJECT}_brain_surface ${SUBJECT}_inner_skull_surface ${SUBJECT}_outer_skull_surface ${SUBJECT}_outer_skin_surface"
+    for s in $surfaces ; do
+	mne_convert_surface --surf $s --mghmri $T1_mgz --surfout $s
+    done
+fi
+cd $bem_dir
+rm -f $SUBJECT-head.fif
+mne_surf2bem --surf $ws_dir/"$SUBJECT"_outer_skin_surface --id 4 --fif $SUBJECT-head.fif
+echo "Created $bem_dir/$SUBJECT-head.fif"
+echo
+echo "Complete."
+echo
+exit 0
+

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     keywords="code",
     url="https://github.com/meeg-cfin/stormdb-python.git",
     packages=['stormdb'],
-    scripts=['bin/submit_to_cluster'],
+    scripts=['bin/submit_to_cluster',
+             'bin/cfin_flash_bem'],
     long_description=read('README.md'),
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
     url="https://github.com/meeg-cfin/stormdb-python.git",
     packages=['stormdb'],
     scripts=['bin/submit_to_cluster',
-             'bin/cfin_flash_bem'],
+             'bin/cfin_flash_bem',
+             'bin/cfin_watershed_bem'],
     long_description=read('README.md'),
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/stormdb/base.py
+++ b/stormdb/base.py
@@ -105,7 +105,7 @@ def add_to_command(cmd, addition, *args, **kwargs):
     fmt = addition.format(*args, **kwargs)
 
     if isinstance(cmd, string_types):
-        cmd = '{:s};\n{:s}'.format(cmd, fmt)
+        cmd = '{:s}\n{:s}'.format(cmd, fmt)
     elif isinstance(cmd, list):
         cmd += ['{:s}'.format(fmt)]
 

--- a/stormdb/base.py
+++ b/stormdb/base.py
@@ -8,6 +8,8 @@ import os
 import errno
 import inspect
 
+from six import string_types
+
 
 def check_destination_writable(dest):
     try:
@@ -73,3 +75,24 @@ def _get_unique_series(qy, series_name, subject, modality):
                            'matches the pattern {0}'.format(series_name))
 
     return series
+
+
+def apply_method(method='recon_all', *args, **kwargs):
+    """Apply a method/function with parameters
+
+    Parameters
+    ----------
+    """
+    # cmd = 'self.' + method + "('{}'".format(*args)
+    cmd = method + "('{0}'".format(*args)
+    for k, v in kwargs.iteritems():
+        # if method_args is not None and k in method_args.keys():
+        #     v = method_args[k]
+
+        if isinstance(v, string_types):
+            cmd += ", {0}='{1}'".format(k, v)
+        else:
+            cmd += ', {0}={1}'.format(k, v)
+
+    cmd += ')'
+    eval(cmd)

--- a/stormdb/base.py
+++ b/stormdb/base.py
@@ -96,3 +96,17 @@ def apply_method(method='recon_all', *args, **kwargs):
 
     cmd += ')'
     eval(cmd)
+
+
+def add_to_command(cmd, addition, *args, **kwargs):
+    if cmd is None:
+        cmd = []
+
+    fmt = addition.format(*args, **kwargs)
+
+    if isinstance(cmd, string_types):
+        cmd = '{:s};\n{:s}'.format(cmd, fmt)
+    elif isinstance(cmd, list):
+        cmd += ['{:s}'.format(fmt)]
+
+    return cmd

--- a/stormdb/cluster.py
+++ b/stormdb/cluster.py
@@ -36,7 +36,7 @@ QSUB_SCHEMA = """
 export OMP_NUM_THREADS=$NSLOTS
 
 echo "Executing following command on $NSLOTS threads:"
-echo -e {exec_cmd:s}
+echo -e "{exec_cmd:s}"
 
 {exec_cmd:s}  # remember to escape quotes on command-liners!
 
@@ -214,7 +214,7 @@ class ClusterJob(object):
                 raise RuntimeError('Each element of the command list should '
                                    'be a single string.')
             else:
-                self._cmd = ';'.join(value)
+                self._cmd = '\n'.join(value)
         elif not isinstance(value, string_types):
             raise RuntimeError('Command should be a single string.')
         else:

--- a/stormdb/process/__init__.py
+++ b/stormdb/process/__init__.py
@@ -7,5 +7,5 @@
 
 from .maxfilter import Maxfilter
 from .mne_python import MNEPython
-from .freesurfer import Freesurfer
+from .freesurfer import Freesurfer, convert_flash_mris_cfin
 from .simnibs import SimNIBS

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -390,12 +390,14 @@ class Freesurfer(ClusterBatch):
         cmd = None
 
         # Just in case: commands below are dependent on it set in environ
-        cmd = add_to_command(cmd, 'export SUBJECTS_DIR={}',
-                             self.info['subjects_dir'])
+        # cmd = add_to_command(cmd, 'export SUBJECTS_DIR={}',
+        #                     self.info['subjects_dir'])
 
-        cmd = add_to_command(cmd, ('mne_watershed_bem --subject {sub:s} '
-                             ' {atl:s} --overwrite'), sub=subject_dirname,
-                             atl=atlas_str)
+        # NB Using local version of mne_watershed_bem
+        cmd = add_to_command(cmd, ('cfin_watershed_bem --sd {sd:s} '
+                                   '--subject {sub:s} {atl:s} --overwrite'),
+                             sd=self.info['subjects_dir'],
+                             sub=subject_dirname, atl=atlas_str)
 
         bem_dir = op.join(self.info['subjects_dir'], subject_dirname, 'bem')
         surf_names = ('inner_skull', 'outer_skull', 'outer_skin')

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -302,8 +302,12 @@ class Freesurfer(ClusterBatch):
                                    job_options=dict(queue='short.q',
                                                     n_threads=1)):
         """Create BEMs for single subject."""
+        if analysis_name is not None:
+            subject += analysis_name
+
         series = _get_unique_series(Query(self.proj_name), flash5,
                                     subject, 'MR')
+        self.logger.info(series[0]['path'])
         mri_dir = op.join(self.info['subjects_dir'], subject, 'mri')
         flash_dir = op.join(mri_dir, 'flash')
         flash_dcm = op.join(flash_dir, 'dicom')  # same for 5 and 30!

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -381,7 +381,7 @@ class Freesurfer(ClusterBatch):
                 'atlas and gcaatlas cannot be used together; choose one.')
         elif atlas:
             atlas_str = '--atlas'
-        elif atlas:
+        elif gcaatlas:
             atlas_str = '--gcaatlas'
         else:
             atlas_str = ''
@@ -409,71 +409,6 @@ class Freesurfer(ClusterBatch):
 
         self.add_job(cmd, job_name='watershed_bem',
                      cleanup=True, **job_options)
-
-
-#     cmd = '''
-# cd ${SUBJECTS_DIR}/${SUBJECT}/bem
-# ln -s watershed/${SUBJECT}_inner_skull_surface ${SUBJECT}-inner_skull.surf
-# ln -s watershed/${SUBJECT}_outer_skin_surface ${SUBJECT}-outer_skin.surf
-# ln -s watershed/${SUBJECT}_outer_skull_surface ${SUBJECT}-outer_skull.surf
-# cd ''' + ad._project_folder
-#     cmd = '''
-# cd ${SUBJECTS_DIR}/${SUBJECT}/bem
-# head=${SUBJECTS_DIR}/${SUBJECT}/bem/${SUBJECT}-head.fif
-# head_low=${SUBJECTS_DIR}/${SUBJECT}/bem/${SUBJECT}-head-lowres.fif
-# if [ -e $head ]; then
-#     printf 'moving existing head surface %s' $head
-#     mv $head $head_low
-# fi
-# # NB: needs the -f flag to continue despite topological errors!
-# ${MNE_PYTHON}/bin/mne make_scalp_surfaces -s ${SUBJECT} -o -f
-# head_medium=${SUBJECTS_DIR}/${SUBJECT}/bem/${SUBJECT}-head-medium.fif
-# printf 'linking %s as main head surface' $head_medium
-# ln -s $head_medium $head
-# '''
-# cmd = """
-# # symlink the raw...../MR/00X.gre_5o_PDW/files to flash/dicom, then
-#
-# src=${SUBJECTS_DIR}/${SUBJECT}/flash/dicom
-# dest=${SUBJECTS_DIR}/${SUBJECT}/flash
-#
-# cd $dest
-# mne_organize_dicom $src
-# ln -s *gre_5* flash05
-# mne_flash_bem --noflash30
-# """
-#
-#         meshfix_opts = ' -u 10 --vertices {:d} --fsmesh'.format(n_vertices)
-#         bem_dir = os.path.join(m2m_outputs['fs_dir'], 'bem')
-#         bem_surfaces = dict(inner_skull='csf.stl',
-#                             outer_skull='skull.stl',
-#                             outer_skin='skin.stl')
-#         for bem_layer, surf in bem_surfaces.items():
-#             surf_fname = os.path.join(m2m_outputs['m2m_dir'], surf)
-#             if not check_source_readable(surf_fname):
-#                 raise RuntimeError(
-#                     'Could not find surface {surf:s}; mri2mesh may have exited'
-#                     ' with an error, please check.'.format(surf=surf))
-#             bem_fname = os.path.join(bem_dir, bem_layer)
-#
-#             cmds = ['meshfix {sfn:s} {mfo:s} -o {bfn:s}'
-#                     .format(sfn=surf_fname, mfo=meshfix_opts, bfn=bem_fname)]
-#
-#             xfm_volume = os.path.join(m2m_outputs['m2m_dir'], 'tmp',
-#                                       'subcortical_FS.nii.gz')
-#             xfm = os.path.join(m2m_outputs['m2m_dir'], 'tmp', 'unity.xfm')
-#
-#             # NB This is needed! Otherwise the stl->fsmesh conversion output
-#             # lacks some transformation and is misaligned with the MR
-#             cmds += ['mris_transform --dst {xv:s} --src {xv:s} '
-#                      '{bfn:s}.fsmesh {xfm:s} {bfn:s}.surf'
-#                      .format(xv=xfm_volume, bfn=bem_fname, xfm=xfm)]
-#             cmds += ['rm {bfn:s}.fsmesh'.format(bfn=bem_fname)]
-#
-#         # One job per subject, since these are "cheap" operations
-#         self.add_job(cmds, job_name='meshfix',
-#                      working_dir=self.info['output_dir'],
-#                      **job_options)
 
 
 # NB This is a modified version of that found in mne-python/mne/bem.py

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -344,10 +344,10 @@ class Freesurfer(ClusterBatch):
             cmd = add_to_command(cmd, 'cp {}/* {}',
                                  series[0]['path'], flash_dcm)
 
-        cmd = add_to_command(cmd, 'cd {}; mne_organize_dicom {}',
+        cmd = add_to_command(cmd, 'cd {} && mne_organize_dicom {}',
                              flash_dir, flash_dcm)
 
-        cmd = add_to_command(cmd, 'rm flash05; ln -s {} flash05', flash5_name)
+        cmd = add_to_command(cmd, 'rm -f flash05 && ln -s {} flash05', flash5_name)
 
         flash30_str = ' --noflash30'
         if flash30 is not None:
@@ -360,11 +360,10 @@ class Freesurfer(ClusterBatch):
                              subdir=self.info['subjects_dir'])
 
         if make_coreg_head:
-            bem_dir = op.join(mri_dir, 'bem')
+            bem_dir = op.join(mri_dir, '../bem')
             cmd = make_coreg_head_commands(bem_dir, subject_dirname, cmd=cmd)
 
-        self.add_job(cmd, job_name='cfin_flash_bem',
-                     cleanup=True, **job_options)
+        self.add_job(cmd, job_name='cfin_flash_bem', **job_options)
 
     def _create_bem_surfaces_watershed(self, subject, analysis_name=None,
                                        atlas=False, gcaatlas=True,
@@ -409,8 +408,7 @@ class Freesurfer(ClusterBatch):
         if make_coreg_head:
             cmd = make_coreg_head_commands(bem_dir, subject_dirname, cmd=cmd)
 
-        self.add_job(cmd, job_name='watershed_bem',
-                     cleanup=True, **job_options)
+        self.add_job(cmd, job_name='watershed_bem', **job_options)
 
 
 # NB This is a modified version of that found in mne-python/mne/bem.py
@@ -546,12 +544,12 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
 
 def make_coreg_head_commands(bem_dir, subject_dirname, cmd=None):
 
-    cmd = add_to_command(cmd, 'cd {}; mkheadsurf -subjid {}',
+    cmd = add_to_command(cmd, 'cd {} && mkheadsurf -subjid {}',
                          bem_dir, subject_dirname)
     cmd = add_to_command(cmd, ('mne_surf2bem --surf ../surf/lh.seghead '
                          '--id 4 --check --fif {}-head-dense.fif'),
                          subject_dirname)
-    cmd = add_to_command(cmd, ('rm -f {sub:s}-head.fif;'
+    cmd = add_to_command(cmd, ('rm -f {sub:s}-head.fif && '
                          'ln -s {sub:s}-head-dense.fif {sub:s}-head.fif'),
                          sub=subject_dirname)
     return cmd

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -411,7 +411,7 @@ class Freesurfer(ClusterBatch):
                              sub=subject_dirname, atl=atlas_str)
 
         bem_dir = op.join(self.info['subjects_dir'], subject_dirname, 'bem')
-        surf_names = ('inner_skull', 'outer_skull', 'outer_skin')
+        surf_names = ('inner_skull',)
         for sn in surf_names:
             surf_fname = op.join(bem_dir, sn + '.surf')
             cmd = add_to_command(cmd, ('ln -s watershed/{}_{}_surface {}'),

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -605,7 +605,9 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             files = glob.glob("mef05*u.mgz")
         else:
             files = glob.glob("mef05*.mgz")
-        cmd = ['mri_average', '-noconform', files, 'flash5.mgz']
+        cmd = ['mri_average', '-noconform']
+        cmd.extend(files)
+        cmd.append('flash5.mgz')
         run_subprocess(cmd, env=env, stdout=sys.stdout,
                        stderr=sys.stderr)
         if op.exists('flash5_reg.mgz'):

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -556,8 +556,9 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
                 print("The file %s is already there")
             else:
                 cmd = ['mri_convert', sample_file, dest_file]
-                run_subprocess(cmd, env=env, stdout=sys.stdout,
-                               stderr=sys.stderr)
+                _run_subprocess(cmd, stderr=subp.STDOUT, shell=True)
+                # run_subprocess(cmd, env=env, stdout=sys.stdout,
+                #                stderr=sys.stderr)
                 echos_done += 1
     # Step 1b : Run grad_unwarp on converted files
     os.chdir(op.join(mri_dir, "flash"))
@@ -568,8 +569,9 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             outfile = infile.replace(".mgz", "u.mgz")
             cmd = ['grad_unwarp', '-i', infile, '-o', outfile, '-unwarp',
                    'true']
-            run_subprocess(cmd, env=env, stdout=sys.stdout,
-                           stderr=sys.stderr)
+            _run_subprocess(cmd, stderr=subp.STDOUT, shell=True)
+            # run_subprocess(cmd, env=env, stdout=sys.stdout,
+            #                stderr=sys.stderr)
     # Clear parameter maps if some of the data were reconverted
     if echos_done > 0 and op.exists("parameter_maps"):
         shutil.rmtree("parameter_maps")
@@ -583,8 +585,9 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             files = glob.glob("mef05*u.mgz")
         if len(os.listdir('parameter_maps')) == 0:
             cmd = ['mri_ms_fitparms'] + files + ['parameter_maps']
-            run_subprocess(cmd, env=env, stdout=sys.stdout,
-                           stderr=sys.stderr)
+            _run_subprocess(cmd, stderr=subp.STDOUT, shell=True)
+            # run_subprocess(cmd, env=env, stdout=sys.stdout,
+            #                stderr=sys.stderr)
         else:
             print("Parameter maps were already computed")
         # Step 3 : Synthesize the flash 5 images
@@ -593,8 +596,9 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
         if not op.exists('flash5.mgz'):
             cmd = ['mri_synthesize', '20 5 5', 'T1.mgz', 'PD.mgz',
                    'flash5.mgz']
-            run_subprocess(cmd, env=env, stdout=sys.stdout,
-                           stderr=sys.stderr)
+            _run_subprocess(cmd, stderr=subp.STDOUT, shell=True)
+            # run_subprocess(cmd, env=env, stdout=sys.stdout,
+            #                stderr=sys.stderr)
             os.remove('flash5_reg.mgz')
         else:
             print("Synthesized flash 5 volume is already there")
@@ -605,11 +609,10 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             files = glob.glob("mef05*u.mgz")
         else:
             files = glob.glob("mef05*.mgz")
-        cmd = ['mri_average', '-noconform']
-        cmd.extend(files)
-        cmd.append('flash5.mgz')
-        run_subprocess(cmd, env=env, stdout=sys.stdout,
-                       stderr=sys.stderr)
+        cmd = ['mri_average', '-noconform'] + files + ['flash5.mgz']
+        _run_subprocess(cmd, stderr=subp.STDOUT, shell=True)
+        # run_subprocess(cmd, env=env, stdout=sys.stdout,
+        #                stderr=sys.stderr)
         if op.exists('flash5_reg.mgz'):
             os.remove('flash5_reg.mgz')
 

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -390,7 +390,9 @@ class Freesurfer(ClusterBatch):
 
         env = os.environ.copy()
         self.logger.info('Running mne_watershed_bem...')
-
+        print(env['SUBJECTS_DIR'])
+        print(self.info['subjects_dir'])
+        print(subject_dirname)
         ws_cmd = ['mne_watershed_bem --subject {sub:s} {atl:s} '
                   '--overwrite'.format(sub=subject_dirname, atl=atlas_str)]
 
@@ -409,8 +411,8 @@ class Freesurfer(ClusterBatch):
                 head_cmds += ['export SUBJECTS_DIR={}'
                               .format(self.info['subjects_dir'])]
 
-            head_cmds = 'cd {}; mkheadsurf -subjid {}'.format(bem_dir,
-                                                              subject_dirname)
+            head_cmds = ['cd {}; mkheadsurf -subjid {}'.format(bem_dir,
+                                                               subject_dirname)]
             head_cmds += ['mne_surf2bem --surf ../surf/lh.smseghead --id 4 '
                           '--check --fif {}-head-dense.fif'
                           .format(subject_dirname)]
@@ -647,7 +649,7 @@ def _prepare_env(subject, subjects_dir, requires_freesurfer, requires_mne):
 
 def _run_subprocess(cmd, msg=None, **kwargs):
     if isinstance(cmd, string_types):
-        cmd = list(cmd)
+        cmd = [cmd]
     try:
         subp.check_output(cmd, **kwargs)
     except subp.CalledProcessError as cpe:

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -330,10 +330,9 @@ class Freesurfer(ClusterBatch):
         flash_dir = op.join(mri_dir, 'flash')
         flash_dcm = op.join(flash_dir, 'dicom')  # same for 5 and 30!
 
-        if os.isdir(flash_dcm):
+        if op.isdir(flash_dcm):
             warn('Copy of FLASH image DICOMs found. Submitting this script '
                  'will overwrite previous surfaces.')
-            cmd = add_to_command(cmd, 'rm -rf {}/*', flash_dir)
 
         cmd = add_to_command(cmd, 'mkdir -p {}', flash_dcm)
         cmd = add_to_command(cmd, 'cp {}/* {}', series[0]['path'], flash_dcm)

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -326,7 +326,7 @@ class Freesurfer(ClusterBatch):
         mri_dir = op.join(self.info['subjects_dir'], subject_dir, 'mri')
         flash_dir = op.join(mri_dir, 'flash')
         flash_dcm = op.join(flash_dir, 'dicom')  # same for 5 and 30!
-        make_copy_of_dicom_dir(series[0]['path'], flash_dcm)
+#        make_copy_of_dicom_dir(series[0]['path'], flash_dcm)
         if flash30 is not None:
             series = _get_unique_series(Query(self.proj_name), flash30,
                                         subject, 'MR')
@@ -334,32 +334,35 @@ class Freesurfer(ClusterBatch):
             make_copy_of_dicom_dir(series[0]['path'], flash_dcm)
 
         self.logger.info('Running mne_organize_dicom...')
-        cmd = 'cd {}; mne_organize_dicom {}; cd -'.format(flash_dir, flash_dcm)
+        cmd = 'cd {}; mne_organize_dicom {}; '.format(flash_dir, flash_dcm)
+        cmd = ''  # DEBUG
+
+
+#        flash5_dir = op.join(flash_dir, flash5_name)
+#        flash5_link = op.realpath(op.join(flash_dir, 'flash05'))
+#        os.symlink(flash5_dir, flash5_link)
+        cmd += 'ln -s {} flash05 ;'.format(flash5_name)
+
+        if flash30 is not None:
+#            flash30_dir = op.join(flash_dir, flash30_name)
+#            flash30_link = op.realpath(op.join(flash_dir, 'flash30'))
+#            os.symlink(flash30_dir, flash30_link)
+            cmd += 'ln -s {} flash30 ;'.format(flash30_name)
+
+        print(cmd)
         try:
             subp.check_output([cmd], stderr=subp.STDOUT, shell=True)
         except subp.CalledProcessError as cpe:
             raise RuntimeError('mne_organize_dicom failed with error message: '
                                '{:s}'.format(cpe.returncode, cpe.output))
-        ### CUT ###
-        # NB DEBUG
-        _run_subprocess('cd {}; ln -s 005_gre* 005_{}'
-                        .format(flash_dir, flash5_name))
-        _run_subprocess('cd {}; ln -s 006_gre* 006_{}'
-                        .format(flash_dir, flash30_name))
-        ### CUT ###
 
-        flash5_dir = op.join(flash_dir, flash5_name)
-        os.symlink(flash5_dir, op.join(flash_dir, 'flash05'))
-        if flash30 is not None:
-            flash30_dir = op.join(flash_dir, flash30_name)
-            os.symlink(flash30_dir, op.join(flash_dir, 'flash30'))
 
-        n_echos = len(os.listdir(op.join(flash_dir, 'flash05')))
+        n_echos = len(os.listdir(flash5_link))
         if n_echos < 3:
             raise ValueError(
                 'Less than 3 echos are currently not supported.')
         elif flash30 is not None:
-            n_echos_30 = len(os.listdir(op.join(flash_dir, 'flash30')))
+            n_echos_30 = len(os.listdir(flash30_link))
             if n_echos_30 != n_echos:
                 raise ValueError(
                     '5 and 30 degree sequences must have equal no. echos, '
@@ -408,7 +411,7 @@ class Freesurfer(ClusterBatch):
             head_cmds = []
             head_cmds = ['cd {}; mkheadsurf -subjid {}'.format(bem_dir,
                                                                subject_dirname)]
-            head_cmds += ['mne_surf2bem --surf ../surf/lh.smseghead --id 4 '
+            head_cmds += ['mne_surf2bem --surf ../surf/lh.seghead --id 4 '
                           '--check --fif {}-head-dense.fif'
                           .format(subject_dirname)]
             head_cmds += ['rm -f {sub:s}-head.fif;'
@@ -418,9 +421,8 @@ class Freesurfer(ClusterBatch):
         cmd = ' ;\n'.join(ws_cmd + ln_cmds + head_cmds)
 
         # Just in case: commands below are dependent on it set in environ
-        if 'SUBJECTS_DIR' not in os.environ.keys():
-            cmd = ('export SUBJECTS_DIR={} ;\n'
-                   .format(self.info['subjects_dir'])) + cmd
+        cmd = ('export SUBJECTS_DIR={} ;\n'
+               .format(self.info['subjects_dir'])) + cmd
         # NB CLUSTERISE!
         _run_subprocess(cmd, stderr=subp.STDOUT, shell=True)
 #     cmd = '''

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -368,7 +368,7 @@ class Freesurfer(ClusterBatch):
                                    """-type d -name "0*" | wc -l)"""))
 
         cmd = add_to_command(cmd, ('cfin_flash_bem -s {sub:s} -d {subdir:s}'
-                                   '{f30_str:s} -e $(n_echos)'),
+                                   '{f30_str:s} -e $\{n_echos\}'),
                              sub=subject_dir, subdir=self.info['subjects_dir'],
                              f30_str=flash30_str)
         self.add_job(cmd, job_name='cfin_flash_bem', **job_options)

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -330,9 +330,10 @@ class Freesurfer(ClusterBatch):
         flash_dir = op.join(mri_dir, 'flash')
         flash_dcm = op.join(flash_dir, 'dicom')  # same for 5 and 30!
 
-        if op.isdir(flash_dcm):
+        if os.isdir(flash_dcm):
             warn('Copy of FLASH image DICOMs found. Submitting this script '
                  'will overwrite previous surfaces.')
+            cmd = add_to_command(cmd, 'rm -rf {}/*', flash_dir)
 
         cmd = add_to_command(cmd, 'mkdir -p {}', flash_dcm)
         cmd = add_to_command(cmd, 'cp {}/* {}', series[0]['path'], flash_dcm)
@@ -340,8 +341,7 @@ class Freesurfer(ClusterBatch):
         if flash30 is not None:
             series = _get_unique_series(Query(self.proj_name), flash30,
                                         subject, 'MR')
-            flash30_name = '{:03d}_{:s}'.format(int(series[0]['serieno']),
-                                                series[0]['seriename'])
+            flash30_name = series[0]['seriename']
             cmd = add_to_command(cmd, 'cp {}/* {}',
                                  series[0]['path'], flash_dcm)
 
@@ -350,10 +350,10 @@ class Freesurfer(ClusterBatch):
 
         cmd = add_to_command(cmd, 'rm flash05; ln -s {} flash05', flash5_name)
 
-        flash30_str = ' --noflash30'
+        flash30_str = ''
         if flash30 is not None:
             cmd = add_to_command(cmd, 'ln -s {} flash30', flash30_name)
-            flash30_str = ''
+            flash30_str = ' --noflash30'
 
         cmd = add_to_command(cmd, ('cfin_flash_bem -s {sub:s} -d {subdir:s}'
                                    '{f30_str:s} --overwrite'),
@@ -505,9 +505,9 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
     should be, as usual, in the subject's mri directory.
     """
 
-    if n_echos < 3:
+    if n_echos < 5:
         raise ValueError(
-            'Less than 3 echos are currently not supported.')
+            'Less than 5 echos are currently not supported.')
     elif flash30 and n_echos != 8:
         raise ValueError(
             'When using the 30 degree sequence, exactly 8 echos must be used')
@@ -598,12 +598,11 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             print("Synthesized flash 5 volume is already there")
     else:
         print("\n---- Averaging flash5 echoes ----")
-        # This must be an mne-python BUG!
-        # os.chdir('parameter_maps')
+        os.chdir('parameter_maps')
         if unwarp:
-            files = glob.glob("mef05*u.mgz")
+            files = glob.glob("../mef05*u.mgz")
         else:
-            files = glob.glob("mef05*.mgz")
+            files = glob.glob("../mef05*.mgz")
         cmd = ['mri_average', '-noconform'] + files + ['flash5.mgz']
         _run_subprocess(cmd, stderr=subp.STDOUT, shell=True)
         if op.exists('flash5_reg.mgz'):

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -365,8 +365,8 @@ class Freesurfer(ClusterBatch):
         surf_names = ('inner_skull', 'outer_skull', 'outer_skin')
         flash5_reg = op.join(flash_dir, 'parameter_maps', 'flash5_reg.mgz')
         for sn in surf_names:
-            tri_fname = op.join(bem_dir, sn + '.tri')
-            surf_fname = op.join(bem_dir, sn + '.surf')
+            tri_fname = op.join(bem_dir, 'flash', sn + '.tri')
+            surf_fname = op.join(bem_dir, 'flash', sn + '.surf')
             cmd = add_to_command(cmd,
                                  ('mne_convert_surface --tri {tri:s} '
                                   ' --surfout {surf:s} --swap --mghmri '

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -594,7 +594,6 @@ def _run_subprocess(cmd, msg=None, **kwargs):
             # for some reason check_output fails if cmd is not a string
             cmd = ' '.join(cmd)
     try:
-        print(cmd)
         subp.check_output(cmd, **kwargs)
     except subp.CalledProcessError as cpe:
         if msg is None:

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -366,17 +366,17 @@ class Freesurfer(ClusterBatch):
         cmd = add_to_command(cmd, ("n_echos=$(find flash05 "
                                    """-type d -name "0*" | wc -l)"""))
 
-        n_echos = len(os.listdir(flash5_link))
-        if n_echos < 3:
-            raise ValueError(
-                'Less than 3 echos are currently not supported.')
-        elif flash30 is not None:
-            n_echos_30 = len(os.listdir(flash30_link))
-            if n_echos_30 != n_echos:
-                raise ValueError(
-                    '5 and 30 degree sequences must have equal no. echos, '
-                    'found {} and {}, resp.'.format(n_echos, n_echos_30))
-        self.logger.info('Found {:d} multi-echos...'.format(n_echos))
+        # n_echos = len(os.listdir(flash5_link))
+        # if n_echos < 3:
+        #     raise ValueError(
+        #         'Less than 3 echos are currently not supported.')
+        # elif flash30 is not None:
+        #     n_echos_30 = len(os.listdir(flash30_link))
+        #     if n_echos_30 != n_echos:
+        #         raise ValueError(
+        #             '5 and 30 degree sequences must have equal no. echos, '
+        #             'found {} and {}, resp.'.format(n_echos, n_echos_30))
+        # self.logger.info('Found {:d} multi-echos...'.format(n_echos))
 
         # The function below handles logging messages
         convert_flash_mris_cfin(subject, flash30=flash30, n_echos=n_echos,

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -369,9 +369,9 @@ class Freesurfer(ClusterBatch):
             surf_fname = op.join(bem_dir, sn + '.surf')
             cmd = add_to_command(cmd,
                                  ('mne_convert_surface --tri {tri:s} '
-                                  ' --surfout {surf:s} --swap --mghmri ',
-                                  '{flreg:s}'), tri=tri_fname, surf=surf_fname,
-                                 flreg=flash5_reg)
+                                  ' --surfout {surf:s} --swap --mghmri '
+                                  '{f5reg:s}'), tri=tri_fname, surf=surf_fname,
+                                 f5reg=flash5_reg)
         if make_coreg_head:
             cmd = make_coreg_head_commands(bem_dir, subject_dirname, cmd=cmd)
 

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -379,7 +379,7 @@ class Freesurfer(ClusterBatch):
         # self.logger.info('Found {:d} multi-echos...'.format(n_echos))
 
         # The function below handles logging messages
-        convert_flash_mris_cfin(subject, flash30=flash30, n_echos=n_echos,
+        convert_flash_mris_cfin(subject, flash30=flash30, n_echos=8,
                                 subjects_dir=self.info['subjects_dir'],
                                 logger=self.logger)
         self.logger.info('...done')

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -330,10 +330,9 @@ class Freesurfer(ClusterBatch):
         flash_dir = op.join(mri_dir, 'flash')
         flash_dcm = op.join(flash_dir, 'dicom')  # same for 5 and 30!
 
-        if os.isdir(flash_dcm):
+        if op.isdir(flash_dcm):
             warn('Copy of FLASH image DICOMs found. Submitting this script '
                  'will overwrite previous surfaces.')
-            cmd = add_to_command(cmd, 'rm -rf {}/*', flash_dir)
 
         cmd = add_to_command(cmd, 'mkdir -p {}', flash_dcm)
         cmd = add_to_command(cmd, 'cp {}/* {}', series[0]['path'], flash_dcm)
@@ -341,7 +340,8 @@ class Freesurfer(ClusterBatch):
         if flash30 is not None:
             series = _get_unique_series(Query(self.proj_name), flash30,
                                         subject, 'MR')
-            flash30_name = series[0]['seriename']
+            flash30_name = '{:03d}_{:s}'.format(int(series[0]['serieno']),
+                                                series[0]['seriename'])
             cmd = add_to_command(cmd, 'cp {}/* {}',
                                  series[0]['path'], flash_dcm)
 
@@ -350,10 +350,10 @@ class Freesurfer(ClusterBatch):
 
         cmd = add_to_command(cmd, 'rm flash05; ln -s {} flash05', flash5_name)
 
-        flash30_str = ''
+        flash30_str = ' --noflash30'
         if flash30 is not None:
             cmd = add_to_command(cmd, 'ln -s {} flash30', flash30_name)
-            flash30_str = ' --noflash30'
+            flash30_str = ''
 
         cmd = add_to_command(cmd, ('cfin_flash_bem -s {sub:s} -d {subdir:s}'
                                    '{f30_str:s} --overwrite'),
@@ -598,7 +598,8 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             print("Synthesized flash 5 volume is already there")
     else:
         print("\n---- Averaging flash5 echoes ----")
-        os.chdir('parameter_maps')
+        # This must be an mne-python BUG!
+        # os.chdir('parameter_maps')
         if unwarp:
             files = glob.glob("mef05*u.mgz")
         else:

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -364,11 +364,11 @@ class Freesurfer(ClusterBatch):
         #     raise RuntimeError('mne_organize_dicom failed with error message: '
         #                        '{:s}'.format(cpe.returncode, cpe.output))
 
-        cmd = add_to_command(cmd, ("n_echos=$(find flash05 "
+        cmd = add_to_command(cmd, ("NECHOS=$(find flash05 "
                                    """-type d -name "0*" | wc -l)"""))
 
         cmd = add_to_command(cmd, ('cfin_flash_bem -s {sub:s} -d {subdir:s}'
-                                   '{f30_str:s} -e ${n_echos}'),
+                                   '{f30_str:s} -e $NECHOS'),
                              sub=subject_dir, subdir=self.info['subjects_dir'],
                              f30_str=flash30_str)
         self.add_job(cmd, job_name='cfin_flash_bem', **job_options)

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -358,7 +358,6 @@ class Freesurfer(ClusterBatch):
 #            flash30_link = op.realpath(op.join(flash_dir, 'flash30'))
 #            os.symlink(flash30_dir, flash30_link)
 
-        print(cmd)
         # try:
         #     subp.check_output([cmd], stderr=subp.STDOUT, shell=True)
         # except subp.CalledProcessError as cpe:

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -368,7 +368,7 @@ class Freesurfer(ClusterBatch):
                                    """-type d -name "0*" | wc -l)"""))
 
         cmd = add_to_command(cmd, ('cfin_flash_bem -s {sub:s} -d {subdir:s}'
-                                   '{f30_str:s} -e $\{n_echos\}'),
+                                   '{f30_str:s} -e ${n_echos}'),
                              sub=subject_dir, subdir=self.info['subjects_dir'],
                              f30_str=flash30_str)
         self.add_job(cmd, job_name='cfin_flash_bem', **job_options)

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -12,8 +12,10 @@ import os.path as op
 import subprocess as subp
 import shutil
 import glob
+import sys
 
 from six import string_types
+from mne.utils import run_subprocess
 
 from .utils import first_file_in_dir, make_copy_of_dicom_dir
 from ..base import (enforce_path_exists, check_source_readable,
@@ -554,7 +556,8 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
                 print("The file %s is already there")
             else:
                 cmd = ['mri_convert', sample_file, dest_file]
-                _run_subprocess(cmd, env=env, stderr=subp.STDOUT)
+                run_subprocess(cmd, env=env, stdout=sys.stdout,
+                               stderr=sys.stderr)
                 echos_done += 1
     # Step 1b : Run grad_unwarp on converted files
     os.chdir(op.join(mri_dir, "flash"))
@@ -565,7 +568,8 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             outfile = infile.replace(".mgz", "u.mgz")
             cmd = ['grad_unwarp', '-i', infile, '-o', outfile, '-unwarp',
                    'true']
-            _run_subprocess(cmd, env=env, stderr=subp.STDOUT)
+            run_subprocess(cmd, env=env, stdout=sys.stdout,
+                           stderr=sys.stderr)
     # Clear parameter maps if some of the data were reconverted
     if echos_done > 0 and op.exists("parameter_maps"):
         shutil.rmtree("parameter_maps")
@@ -579,7 +583,8 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
             files = glob.glob("mef05*u.mgz")
         if len(os.listdir('parameter_maps')) == 0:
             cmd = ['mri_ms_fitparms'] + files + ['parameter_maps']
-            _run_subprocess(cmd, env=env, stderr=subp.STDOUT)
+            run_subprocess(cmd, env=env, stdout=sys.stdout,
+                           stderr=sys.stderr)
         else:
             print("Parameter maps were already computed")
         # Step 3 : Synthesize the flash 5 images
@@ -588,7 +593,8 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
         if not op.exists('flash5.mgz'):
             cmd = ['mri_synthesize', '20 5 5', 'T1.mgz', 'PD.mgz',
                    'flash5.mgz']
-            _run_subprocess(cmd, env=env, stderr=subp.STDOUT)
+            run_subprocess(cmd, env=env, stdout=sys.stdout,
+                           stderr=sys.stderr)
             os.remove('flash5_reg.mgz')
         else:
             print("Synthesized flash 5 volume is already there")
@@ -600,7 +606,8 @@ def convert_flash_mris_cfin(subject, flash30=False, n_echos=8,
         else:
             files = glob.glob("mef05*.mgz")
         cmd = ['mri_average', '-noconform', files, 'flash5.mgz']
-        _run_subprocess(cmd, env=env, stderr=subp.STDOUT)
+        run_subprocess(cmd, env=env, stdout=sys.stdout,
+                       stderr=sys.stderr)
         if op.exists('flash5_reg.mgz'):
             os.remove('flash5_reg.mgz')
 

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -349,10 +349,10 @@ class Freesurfer(ClusterBatch):
 
         cmd = add_to_command(cmd, 'rm flash05; ln -s {} flash05', flash5_name)
 
-        flash30_str = ''
+        flash30_str = ' --noflash30'
         if flash30 is not None:
             cmd = add_to_command(cmd, 'ln -s {} flash30', flash30_name)
-            flash30_str = ' --noflash30'
+            flash30_str = ''
 
         cmd = add_to_command(cmd, ('cfin_flash_bem -s {sub:s} -d {subdir:s}'
                                    '{f30_str:s} --overwrite'),

--- a/stormdb/process/freesurfer.py
+++ b/stormdb/process/freesurfer.py
@@ -370,8 +370,8 @@ class Freesurfer(ClusterBatch):
             cmd = add_to_command(cmd,
                                  ('mne_convert_surface --tri {tri:s} '
                                   ' --surfout {surf:s} --swap --mghmri ',
-                                  '{f5reg:s}'), tri=tri_fname, surf=surf_fname,
-                                 f5reg=flash5_reg)
+                                  '{flreg:s}'), tri=tri_fname, surf=surf_fname,
+                                 flreg=flash5_reg)
         if make_coreg_head:
             cmd = make_coreg_head_commands(bem_dir, subject_dirname, cmd=cmd)
 

--- a/stormdb/process/utils.py
+++ b/stormdb/process/utils.py
@@ -21,8 +21,12 @@ def make_copy_of_dicom_dir(dicom_dir, out_dir=None):
         out_dir = tempfile.mkdtemp()
     else:
         mkdir_p(out_dir)
-    # NB this silently does nothing if glob finds nothing!
-    for dcm in glob(os.path.join(dicom_dir, '*.*')):
+
+    all_files = glob(os.path.join(dicom_dir, '*.*'))
+    if len(all_files) == 0:
+        raise RuntimeError(
+            'No files to copy found in {}'.format(dicom_dir))
+    for dcm in all_files:
         shutil.copy(dcm, out_dir)
     return out_dir
 

--- a/stormdb/process/utils.py
+++ b/stormdb/process/utils.py
@@ -21,6 +21,7 @@ def make_copy_of_dicom_dir(dicom_dir, out_dir=None):
         out_dir = tempfile.mkdtemp()
     else:
         mkdir_p(out_dir)
+    # NB this silently does nothing if glob finds nothing!
     for dcm in glob(os.path.join(dicom_dir, '*.*')):
         shutil.copy(dcm, out_dir)
     return out_dir

--- a/stormdb/process/utils.py
+++ b/stormdb/process/utils.py
@@ -13,12 +13,17 @@ import shutil
 import tempfile
 from glob import glob
 
+from ..base import mkdir_p
 
-def make_copy_of_dicom_dir(dicom_dir):
-    tmpdir = tempfile.mkdtemp()
+
+def make_copy_of_dicom_dir(dicom_dir, out_dir=None):
+    if out_dir is None:
+        out_dir = tempfile.mkdtemp()
+    else:
+        mkdir_p(out_dir)
     for dcm in glob(os.path.join(dicom_dir, '*.*')):
-        shutil.copy(dcm, tmpdir)
-    return tmpdir
+        shutil.copy(dcm, out_dir)
+    return out_dir
 
 
 def first_file_in_dir(input_dir):


### PR DESCRIPTION
Allows calling 

```python
>>> from stormdb.process import Freesurfer
>>> fs = Freesurfer(subjects_dir='scratch/fs_subjects_dir')
```

For watershed-based `inner_skull` surface

```python
>>> fs.create_bem_surfaces('0002_M55')
```

With a 5-degree multi-echo FLASH sequence matching the wildcard `*gre*5*`, create `inner_skull`, `outer_skull` and `outer_skin` surfaces:

```python
>>> fs.create_bem_surfaces('0002_M55', flash5='*gre*5*')
```

Finally, submit

```python
>>> fs.submit()  # doctest: +SKIP
```

