### PR TITLE
Specify dependencies using pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,39 @@ stormdb-python
 
 __NB! Help with documentation and examples needed!__
 
+Command line utility: `submit_to_cluster`
+-----------------------------------------
+Install with [uv](https://docs.astral.sh/uv/) by calling
+
+``` bash
+uv tool install "stormdb @ https://github.com/meeg-cfin/stormdb-python.git"
+```
+
+which creates symlinks in your `~/.local/bin` that lets you use `submit_to_cluster` 
+
+```
+usage: submit_to_cluster [-h] [-n N_THREADS] [-q QUEUE] [-m TOTAL_MEMORY] [-p PROJECT] [-w WORKING_DIR] [--noclean] exec_cmd
+
+positional arguments:
+  exec_cmd              Full command to execute, in quotes (")
+
+options:
+  -h, --help            show this help message and exit
+  -n N_THREADS, --n_threads N_THREADS
+                        Number of threads to run per process.
+  -q QUEUE, --queue QUEUE
+                        Name of queue to submit to
+  -m TOTAL_MEMORY, --total_memory TOTAL_MEMORY
+                        Total amount of memory to request (max 1 thread). Format: M=megabytes, G=gigabytes (e.g. 30G). See docstring of
+                        `ClusterJob` for details!
+  -p PROJECT, --project PROJECT
+                        Name of project (or set MINDLABPROJ)
+  -w WORKING_DIR, --working_dir WORKING_DIR
+                        Working directory for the job (default: cwd)
+  --noclean             Do not clean up the qsub submission script.
+```
+
+
 Submodule: access
 -----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "stormdb"
+version = "0.7.dev0"
+description = "Tools for accessing StormDb @ CFIN"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "requests",
+    "six",
+]


### PR DESCRIPTION
"six" and "requests" are both implicit dependencies that a package manager will need to fetch

This would allow users to install submit_to_cluster including dependencies with uv

Example (currently working, using the branch in this PR):
> uv tool install "stormdb @ https://github.com/maltelau/stormdb-python.git"
> ls ~/.local/bin/submit_to_cluster
/users/maltelau/.local/bin/submit_to_cluster

Would work after this PR:
uv tool install "stormdb @ https://github.com/meeg-cfin/stormdb-python.git"